### PR TITLE
Schedule cleanups when using the FileDB as well

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -591,6 +591,8 @@ class FileDB extends Cache
     if (olddatapath)
       fs.unlink(olddatapath, err => err);
 
+    this.cleans = 1;
+
     return true;
   }
 


### PR DESCRIPTION
This matches how it was done for SQLCache before (except setting
the cleans variable to 1 instead of 2, only scheduling one cleanup).