### PR TITLE
Only run cleanup once a minute instead of once per second

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -354,7 +354,7 @@ class SQLCache extends Cache
       yield runSQLiteCmd(cb => this.db.run("CREATE TABLE IF NOT EXISTS lrucache(key VARCHAR, len INTEGER, lastuse INTEGER)", cb));
       yield runSQLiteCmd(cb => this.db.run("CREATE INDEX IF NOT EXISTS lrucacheindex ON lrucache(key)", cb));
 
-      setInterval(() => this._cleanup(), 1000);
+      setInterval(() => this._cleanup(), 60*1000);
       console.log(`init in ${Date.now()-start}ms`);
       return "ok";
     }.bind(this));
@@ -537,7 +537,7 @@ class FileDB extends Cache
     try
     {
       await this._cleanup(true);
-      setInterval(() => this._cleanup(), 1000);
+      setInterval(() => this._cleanup(), 60*1000);
     }
     catch (e)
     {


### PR DESCRIPTION
This should hopefully still be often enough. In a small cache, the
cleanup run takes 76 millisecond, and if that is run once per second
(as it does in a build with less than 100% cache hit rate), it will
spend 7% of its execution time on sorting the cache index in the
cleanup function.